### PR TITLE
Use `--frozen` for `uv sync` and refine project setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,4 @@ jobs:
       - run: uv python install 3.11
       - run: uv sync --extra {{ matrix.extra }} --frozen
       - run: uv run pytest tests/imports_checks/test_{{ matrix.extra }}_imports.py
+    continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,19 @@ jobs:
       - run: uv sync --all-extras --frozen
       - run: make test
     continue-on-error: true
+    tests-imports:
+      runs-on: ${{ matrix.os }}
+      strategy:
+        matrix:
+          extra: [ 'mljar','spliter','deepchecks','editor']
+      steps:
+        - uses: actions/checkout@v4
+        - name: Install OS Dependencies
+          if: matrix.os == 'macos-latest'
+          run: brew install libomp
+        - uses: astral-sh/setup-uv@v4
+          with:
+            enable-cache: true
+        - run: uv python install 3.11
+        - run: uv sync --extra {{ matrix.extra }} --frozen
+        - run: uv run pytest tests/imports_checks/test_{{ matrix.extra }}_imports.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,19 +27,19 @@ jobs:
       - run: uv sync --all-extras --frozen
       - run: make test
     continue-on-error: true
-    tests-imports:
-      runs-on: ${{ matrix.os }}
-      strategy:
-        matrix:
-          extra: [ 'mljar','spliter','deepchecks','editor']
-      steps:
-        - uses: actions/checkout@v4
-        - name: Install OS Dependencies
-          if: matrix.os == 'macos-latest'
-          run: brew install libomp
-        - uses: astral-sh/setup-uv@v4
-          with:
-            enable-cache: true
-        - run: uv python install 3.11
-        - run: uv sync --extra {{ matrix.extra }} --frozen
-        - run: uv run pytest tests/imports_checks/test_{{ matrix.extra }}_imports.py
+  tests-imports:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        extra: [ 'mljar','spliter','deepchecks','editor']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install OS Dependencies
+        if: matrix.os == 'macos-latest'
+        run: brew install libomp
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+      - run: uv python install 3.11
+      - run: uv sync --extra {{ matrix.extra }} --frozen
+      - run: uv run pytest tests/imports_checks/test_{{ matrix.extra }}_imports.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           enable-cache: true
       - run: uv python install ${{ matrix.python-version }}
-      - run: uv sync --all-extras
+      - run: uv sync --all-extras --frozen
       - run: make test
     continue-on-error: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           enable-cache: true
       - run: uv python install 3.11
-      - run: uv sync --all-extras
+      - run: make
       - run: make check
       - run: make build-kfp
         continue-on-error: true

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
-        with:
-          enable-cache: true
       - run: uv python install 3.11
       - run: make
       - run: make check

--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -11,13 +11,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
       - run: uv python install 3.11
       - run: make
       - run: make check
       - run: make build-kfp
         continue-on-error: true
-
-
 
       - name: Check for changes
         id: check_changes

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           enable-cache: true
       - run: uv python install 3.11
-      - run: uv sync --all-extras
+      - run: uv sync --all-extras --frozen
 
       - run: make coverage
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/test-imports.yml
+++ b/.github/workflows/test-imports.yml
@@ -11,7 +11,7 @@ on:
 jobs:
 
   tests-imports:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         extra: [ 'mljar','spliter','deepchecks','editor']

--- a/.github/workflows/test-imports.yml
+++ b/.github/workflows/test-imports.yml
@@ -24,6 +24,6 @@ jobs:
         with:
           enable-cache: true
       - run: uv python install 3.11
-      - run: uv sync --extra {{ matrix.extra }} --frozen
-      - run: uv run pytest tests/imports_checks/test_{{ matrix.extra }}_imports.py
+      - run: uv sync --extra ${{ matrix.extra }} --frozen
+      - run: uv run pytest tests/imports_checks/test_${{ matrix.extra }}_imports.py
     continue-on-error: true

--- a/.github/workflows/test-imports.yml
+++ b/.github/workflows/test-imports.yml
@@ -1,4 +1,4 @@
-name: PR tests
+name: tests-imports
 on:
   pull_request:
     paths:
@@ -9,12 +9,12 @@ on:
         - 'uv.lock'
   workflow_dispatch:
 jobs:
-  tests:
+
+  tests-imports:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        extra: [ 'mljar','spliter','deepchecks','editor']
     steps:
       - uses: actions/checkout@v4
       - name: Install OS Dependencies
@@ -23,7 +23,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           enable-cache: true
-      - run: uv python install ${{ matrix.python-version }}
-      - run: uv sync --all-extras --frozen
-      - run: make test
+      - run: uv python install 3.11
+      - run: uv sync --extra {{ matrix.extra }} --frozen
+      - run: uv run pytest tests/imports_checks/test_{{ matrix.extra }}_imports.py
     continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
         args: [ --preview, --fix,--unsafe-fixes ]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.5.4
+    rev: 0.5.9
     hooks:
       - id: uv-lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
       - id: debug-statements
       - id: end-of-file-fixer
@@ -10,7 +10,7 @@ repos:
     hooks:
       - id: nb-ensure-clean
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.8.3
     hooks:
       - id: ruff-format
         args: [ --preview ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,9 @@ repos:
     rev: v0.8.3
     hooks:
       - id: ruff-format
-        args: [ --preview ]
+        args: [ --preview, --config=pyproject.toml ]
       - id: ruff
-        args: [ --preview, --fix,--unsafe-fixes ]
+        args: [ --preview, --fix,--unsafe-fixes, --config=pyproject.toml ]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 0.5.9

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: help
 
 install:
-	uv sync --all-extras
+	uv sync --all-extras --frozen
 	uv tool install pre-commit --with pre-commit-uv --force-reinstall
 
 .PHONY: default

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	uv run pytest
 
 check:
-	uv run pre-commit run --all-files
+	uv run pre-commit run --all-files --show-diff-on-failure
 
 build-kfp:
 	uv run python -m main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "tabular-orchestrated"
 authors = [
-    {name = "DanielAvdar", email = "66269169+DanielAvdar@users.noreply.github.com"},
+    { name = "DanielAvdar", email = "66269169+DanielAvdar@users.noreply.github.com" },
 ]
-license = {text = "MIT"}
+license = { text = "MIT" }
 requires-python = "<=3.12,>=3.9"
 dynamic = ["version"]
 description = ""
@@ -19,8 +19,7 @@ only-include = ["tabular_orchestrated_kfp", "tabular_orchestrated"]
 [project.optional-dependencies]
 editor = [
 
-        "ml-orchestrator[editor]>=0.0.5b0",
-
+    "ml-orchestrator[editor]>=0.0.5b0",
 ]
 
 
@@ -29,15 +28,15 @@ editor = [
 #]
 
 spliter = [
-    "scikit-learn>=1.3.0","ml-orchestrator", "pandas-pyarrow"
+    "scikit-learn>=1.3.0", "ml-orchestrator", "pandas-pyarrow"
 ]
 
 mljar = [
-    "mljar-supervised==1.1.14","ml-orchestrator", "pandas-pyarrow"
+    "mljar-supervised==1.1.14", "ml-orchestrator", "pandas-pyarrow"
 ]
 
 deepchecks = [
-    "eh-tabular-deepchecks>=0.0.4b","ml-orchestrator", "pandas-pyarrow"
+    "eh-tabular-deepchecks>=0.0.4b", "ml-orchestrator", "pandas-pyarrow"
 ]
 
 [dependency-groups]
@@ -73,8 +72,9 @@ fixable = ["ALL"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
-section-order = ["future", "standard-library", "first-party", "local-folder", "third-party"]
-
+section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
+case-sensitive = true
+classes = ["SVC"]
 [tool.mypy]
 python_version = "3.11"
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,6 @@ deepchecks = [
 [dependency-groups]
 dev = [
     "debugpy==1.8.10",
-    "matplotlib<3.9.4",
-    "ml-orchestrator[editor]",
     "google-cloud-aiplatform",
     "pytest>=7.1.2",
     "hypothesis>=6.23.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,7 @@ fixable = ["ALL"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
-section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
-case-sensitive = true
-classes = ["SVC"]
+
 [tool.mypy]
 python_version = "3.11"
 disallow_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,14 @@ readme = "README.md"
 keywords = [
     "python",
 ]
-dependencies = [
-    "setuptools>=75.6.0",
-]
+dependencies = []
 
 [tool.hatch.build.targets.sdist]
 only-include = ["tabular_orchestrated_kfp", "tabular_orchestrated"]
 
 [project.optional-dependencies]
 editor = [
-    "kfp>=2","ml-orchestrator",
+
         "ml-orchestrator[editor]>=0.0.5b0",
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
+name = "tabular-orchestrated"
 authors = [
     {name = "DanielAvdar", email = "66269169+DanielAvdar@users.noreply.github.com"},
 ]
 license = {text = "MIT"}
 requires-python = "<=3.12,>=3.9"
-name = "tabular-orchestrated"
 dynamic = ["version"]
 description = ""
 readme = "README.md"
@@ -14,12 +14,17 @@ keywords = [
 dependencies = [
     "setuptools>=75.6.0",
 ]
+
+[tool.hatch.build.targets.sdist]
+only-include = ["tabular_orchestrated_kfp", "tabular_orchestrated"]
+
 [project.optional-dependencies]
 editor = [
-    "kfp>=2","ml-orchestrator", "pandas-pyarrow",
+    "kfp>=2","ml-orchestrator",
         "ml-orchestrator[editor]>=0.0.5b0",
 
 ]
+
 
 #evalml = [
 #    "evalml>=0.83.0","ml-orchestrator", "pandas-pyarrow"

--- a/tabular_kfp/components.py
+++ b/tabular_kfp/components.py
@@ -1,35 +1,16 @@
 # flake8: noqa: F403, F405, B006
+from importlib.metadata import version
 from typing import *
 
 from kfp.dsl import *
 
 
-@component(base_image="python:3.11", packages_to_install=["tabular-orchestrated[spliter]==0.0.0"])
-def datasplitter(
-    dataset: Input[Dataset] = None,
-    train_dataset: Output[Dataset] = None,
-    test_dataset: Output[Dataset] = None,
-    test_size: float = 0.2,
-    random_state: int = 42,
-    shuffle: bool = True,
-):
-    from tabular_orchestrated.components import DataSplitter
-
-    comp = DataSplitter(
-        dataset=dataset,
-        train_dataset=train_dataset,
-        test_dataset=test_dataset,
-        test_size=test_size,
-        random_state=random_state,
-        shuffle=shuffle,
-    )
-    comp.execute()
-
-
-@component(base_image="python:3.11", packages_to_install=["tabular-orchestrated[mljar]==0.0.0"])
+@component(
+    base_image="python:3.11", packages_to_install=[f"tabular-orchestrated[mljar]=={version('tabular-orchestrated')}"]
+)
 def mljartraining(
     exclude_columns: List[str] = [],
-    target_column: str = "target",
+    target_column: str = "None",
     dataset: Input[Dataset] = None,
     model: Output[Model] = None,
     mljar_automl_params: Dict = {
@@ -53,10 +34,36 @@ def mljartraining(
     comp.execute()
 
 
-@component(base_image="python:3.11", packages_to_install=["tabular-orchestrated[mljar]==0.0.0"])
+@component(
+    base_image="python:3.11", packages_to_install=[f"tabular-orchestrated[spliter]=={version('tabular-orchestrated')}"]
+)
+def datasplitter(
+    dataset: Input[Dataset] = None,
+    train_dataset: Output[Dataset] = None,
+    test_dataset: Output[Dataset] = None,
+    test_size: float = None,
+    random_state: int = None,
+    shuffle: bool = None,
+):
+    from tabular_orchestrated.components import DataSplitter
+
+    comp = DataSplitter(
+        dataset=dataset,
+        train_dataset=train_dataset,
+        test_dataset=test_dataset,
+        test_size=test_size,
+        random_state=random_state,
+        shuffle=shuffle,
+    )
+    comp.execute()
+
+
+@component(
+    base_image="python:3.11", packages_to_install=[f"tabular-orchestrated[mljar]=={version('tabular-orchestrated')}"]
+)
 def evaluatemljar(
     exclude_columns: List[str] = [],
-    target_column: str = "target",
+    target_column: str = "None",
     test_dataset: Input[Dataset] = None,
     model: Input[Model] = None,
     metrics: Output[Metrics] = None,
@@ -75,10 +82,13 @@ def evaluatemljar(
     comp.execute()
 
 
-@component(base_image="python:3.11", packages_to_install=["tabular-orchestrated[deepchecks]==0.0.0"])
+@component(
+    base_image="python:3.11",
+    packages_to_install=[f"tabular-orchestrated[deepchecks]=={version('tabular-orchestrated')}"],
+)
 def dctraintestcomp(
     exclude_columns: List[str] = [],
-    target_column: str = "target",
+    target_column: str = "None",
     report: Output[HTML] = None,
     failed_checks: Output[Metrics] = None,
     train_dataset: Input[Dataset] = None,
@@ -97,10 +107,13 @@ def dctraintestcomp(
     comp.execute()
 
 
-@component(base_image="python:3.11", packages_to_install=["tabular-orchestrated[deepchecks]==0.0.0"])
+@component(
+    base_image="python:3.11",
+    packages_to_install=[f"tabular-orchestrated[deepchecks]=={version('tabular-orchestrated')}"],
+)
 def dcdatacomp(
     exclude_columns: List[str] = [],
-    target_column: str = "target",
+    target_column: str = "None",
     report: Output[HTML] = None,
     failed_checks: Output[Metrics] = None,
     dataset: Input[Dataset] = None,
@@ -117,10 +130,13 @@ def dcdatacomp(
     comp.execute()
 
 
-@component(base_image="python:3.11", packages_to_install=["tabular-orchestrated[deepchecks,mljar]==0.0.0"])
+@component(
+    base_image="python:3.11",
+    packages_to_install=[f"tabular-orchestrated[deepchecks,mljar]=={version('tabular-orchestrated')}"],
+)
 def mljardcmodelcomp(
     exclude_columns: List[str] = [],
-    target_column: str = "target",
+    target_column: str = "None",
     report: Output[HTML] = None,
     failed_checks: Output[Metrics] = None,
     train_dataset: Input[Dataset] = None,
@@ -141,10 +157,13 @@ def mljardcmodelcomp(
     comp.execute()
 
 
-@component(base_image="python:3.11", packages_to_install=["tabular-orchestrated[deepchecks,mljar]==0.0.0"])
+@component(
+    base_image="python:3.11",
+    packages_to_install=[f"tabular-orchestrated[deepchecks,mljar]=={version('tabular-orchestrated')}"],
+)
 def mljardcfullcomp(
     exclude_columns: List[str] = [],
-    target_column: str = "target",
+    target_column: str = "None",
     report: Output[HTML] = None,
     failed_checks: Output[Metrics] = None,
     train_dataset: Input[Dataset] = None,

--- a/tabular_kfp/parse_components.py
+++ b/tabular_kfp/parse_components.py
@@ -1,9 +1,9 @@
+from ml_orchestrator import ComponentParser
+
 from tabular_orchestrated.components import DataSplitter
 from tabular_orchestrated.deepchecks import DCDataComp, DCTrainTestComp
 from tabular_orchestrated.mljar.mljar import EvaluateMLJAR, MLJARTraining
 from tabular_orchestrated.mljar.mljar_deepchecks import MljarDCFullComp, MljarDCModelComp
-
-from ml_orchestrator import ComponentParser
 
 
 def parse_components(file_path: str) -> None:

--- a/tabular_kfp/pipeline_gcp.py
+++ b/tabular_kfp/pipeline_gcp.py
@@ -1,9 +1,9 @@
 # flake8: noqa: F403, F405, B006
 
+from kfp.dsl import pipeline
+
 from tabular_kfp.gcp_comp import bq_read
 from tabular_kfp.pipeline import mljar_pipeline
-
-from kfp.dsl import pipeline
 
 
 @pipeline(name="MLJAR Pipeline", description="A pipeline that performs data splitting, MLJAR training, and evaluation.")

--- a/tabular_orchestrated/components.py
+++ b/tabular_orchestrated/components.py
@@ -1,12 +1,12 @@
 import dataclasses
 from typing import List, Tuple
 
-from tabular_orchestrated.tab_comp import TabComponent
-
 from ml_orchestrator import artifacts
 from ml_orchestrator.artifacts import Input, Output
 from pandas import DataFrame
 from sklearn.model_selection import train_test_split
+
+from tabular_orchestrated.tab_comp import TabComponent
 
 
 @dataclasses.dataclass

--- a/tabular_orchestrated/deepchecks.py
+++ b/tabular_orchestrated/deepchecks.py
@@ -2,14 +2,14 @@ import dataclasses
 from abc import ABC, abstractmethod
 from typing import Any, List
 
-from tabular_orchestrated.tab_comp import ModelComp
-
 from deepchecks.tabular import Dataset as DC_Dataset
 from deepchecks.tabular.suites import data_integrity, full_suite, model_evaluation, train_test_validation
 from ml_orchestrator import artifacts
 from ml_orchestrator.artifacts import Input, Output
 from pandas import DataFrame
 from pandas_pyarrow import convert_to_numpy
+
+from tabular_orchestrated.tab_comp import ModelComp
 
 
 @dataclasses.dataclass

--- a/tabular_orchestrated/mljar/mljar.py
+++ b/tabular_orchestrated/mljar/mljar.py
@@ -2,8 +2,6 @@ import dataclasses
 from pathlib import Path
 from typing import Dict, List, Union
 
-from tabular_orchestrated.tab_comp import ModelComp
-
 import pandas as pd
 from ml_orchestrator import artifacts
 from ml_orchestrator.artifacts import Input, Output
@@ -11,6 +9,8 @@ from pandas import DataFrame
 from pandas.core.dtypes.common import is_numeric_dtype
 from pandas_pyarrow import convert_to_numpy
 from supervised import AutoML
+
+from tabular_orchestrated.tab_comp import ModelComp
 
 
 @dataclasses.dataclass

--- a/tests/comp/conftest.py
+++ b/tests/comp/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from ml_orchestrator import artifacts
 from pandas_pyarrow import convert_to_pyarrow
 from sklearn import datasets
+
 from tabular_orchestrated.components import DataSplitter
 from tabular_orchestrated.deepchecks import DCDataComp, DCFullComp, DCTrainTestComp
 from tabular_orchestrated.mljar.mljar import MLJARTraining

--- a/tests/comp/conftest.py
+++ b/tests/comp/conftest.py
@@ -2,10 +2,6 @@ import dataclasses as dc
 import shutil
 from pathlib import Path
 
-from tabular_orchestrated.components import DataSplitter
-from tabular_orchestrated.deepchecks import DCDataComp, DCFullComp, DCTrainTestComp
-from tabular_orchestrated.mljar.mljar import MLJARTraining
-
 import deepchecks
 import numpy as np
 import pandas as pd
@@ -13,6 +9,9 @@ import pytest
 from ml_orchestrator import artifacts
 from pandas_pyarrow import convert_to_pyarrow
 from sklearn import datasets
+from tabular_orchestrated.components import DataSplitter
+from tabular_orchestrated.deepchecks import DCDataComp, DCFullComp, DCTrainTestComp
+from tabular_orchestrated.mljar.mljar import MLJARTraining
 
 
 @dc.dataclass

--- a/tests/comp/dc/test_comp_run.py
+++ b/tests/comp/dc/test_comp_run.py
@@ -1,9 +1,8 @@
 from pathlib import Path
 
+from ml_orchestrator import artifacts
 from tabular_orchestrated.components import DataSplitter
 from tabular_orchestrated.deepchecks import DCDataComp, DCTrainTestComp
-
-from ml_orchestrator import artifacts
 
 #
 # def test_mljar(get_df_example: artifacts.Dataset, split_op: DataSplitter,

--- a/tests/comp/dc/test_comp_run.py
+++ b/tests/comp/dc/test_comp_run.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from ml_orchestrator import artifacts
+
 from tabular_orchestrated.components import DataSplitter
 from tabular_orchestrated.deepchecks import DCDataComp, DCTrainTestComp
 

--- a/tests/comp/mljar/conftest.py
+++ b/tests/comp/mljar/conftest.py
@@ -1,13 +1,12 @@
 from pathlib import Path
 
+import deepchecks
+import pytest
+from ml_orchestrator import artifacts
 from tabular_orchestrated.components import DataSplitter
 from tabular_orchestrated.deepchecks import DCModelComp
 from tabular_orchestrated.mljar.mljar import EvaluateMLJAR, MLJARTraining
 from tabular_orchestrated.mljar.mljar_deepchecks import MljarDCModelComp
-
-import deepchecks
-import pytest
-from ml_orchestrator import artifacts
 
 
 @pytest.fixture(scope="session")

--- a/tests/comp/mljar/conftest.py
+++ b/tests/comp/mljar/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import deepchecks
 import pytest
 from ml_orchestrator import artifacts
+
 from tabular_orchestrated.components import DataSplitter
 from tabular_orchestrated.deepchecks import DCModelComp
 from tabular_orchestrated.mljar.mljar import EvaluateMLJAR, MLJARTraining

--- a/tests/comp/mljar/test_mljar.py
+++ b/tests/comp/mljar/test_mljar.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 
-from tabular_orchestrated.deepchecks import DCModelComp
-from tabular_orchestrated.mljar.mljar import EvaluateMLJAR, MLJARTraining
-
 from ml_orchestrator import artifacts
 from sklearn import datasets
+from tabular_orchestrated.deepchecks import DCModelComp
+from tabular_orchestrated.mljar.mljar import EvaluateMLJAR, MLJARTraining
 
 dataset_importers = [
     # (datasets.load_iris,'iris'),

--- a/tests/comp/mljar/test_mljar.py
+++ b/tests/comp/mljar/test_mljar.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from ml_orchestrator import artifacts
 from sklearn import datasets
+
 from tabular_orchestrated.deepchecks import DCModelComp
 from tabular_orchestrated.mljar.mljar import EvaluateMLJAR, MLJARTraining
 

--- a/tests/comp/mljar/test_mljar_data_conv.py
+++ b/tests/comp/mljar/test_mljar_data_conv.py
@@ -1,10 +1,9 @@
-from tabular_orchestrated.mljar.mljar import MLJARTraining
-
 import hypothesis as hp
 import pandas as pd
 import pytest
 from hypothesis.extra.pandas import column, data_frames
 from pandas_pyarrow import convert_to_pyarrow
+from tabular_orchestrated.mljar.mljar import MLJARTraining
 
 
 @hp.given(

--- a/tests/comp/mljar/test_mljar_data_conv.py
+++ b/tests/comp/mljar/test_mljar_data_conv.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 from hypothesis.extra.pandas import column, data_frames
 from pandas_pyarrow import convert_to_pyarrow
+
 from tabular_orchestrated.mljar.mljar import MLJARTraining
 
 

--- a/tests/imports_checks/test_deepchecks_imports.py
+++ b/tests/imports_checks/test_deepchecks_imports.py
@@ -1,0 +1,4 @@
+def test_dc_imports():
+    from tabular_orchestrated.deepchecks import DCTrainTestComp, DCDataComp  # noqa
+
+    assert True

--- a/tests/imports_checks/test_editor_imports.py
+++ b/tests/imports_checks/test_editor_imports.py
@@ -1,0 +1,4 @@
+def test_kfp_imports():
+    from tabular_orchestrated_kfp import datasplitter  # noqa
+
+    assert True

--- a/tests/imports_checks/test_mljar_imports.py
+++ b/tests/imports_checks/test_mljar_imports.py
@@ -1,0 +1,4 @@
+def test_mljar_imports():
+    from tabular_orchestrated.mljar.mljar import MLJARTraining  # noqa
+
+    assert True

--- a/tests/imports_checks/test_spliter_imports.py
+++ b/tests/imports_checks/test_spliter_imports.py
@@ -1,0 +1,4 @@
+def test_spliter_imports():
+    from tabular_orchestrated.components import DataSplitter  # noqa
+
+    assert True

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,7 +1,6 @@
+from kfp import compiler
 from tabular_kfp.pipeline import mljar_pipeline
 from tabular_kfp.pipeline_gcp import mljar_gcp_pipeline
-
-from kfp import compiler
 
 
 def test_compile_core(tmp_files_folder):

--- a/tests/test_compile.py
+++ b/tests/test_compile.py
@@ -1,4 +1,5 @@
 from kfp import compiler
+
 from tabular_kfp.pipeline import mljar_pipeline
 from tabular_kfp.pipeline_gcp import mljar_gcp_pipeline
 

--- a/uv.lock
+++ b/uv.lock
@@ -2770,7 +2770,7 @@ wheels = [
 
 [[package]]
 name = "tabular-orchestrated"
-version = "0.0.14b0.post9.dev0+7668da8"
+version = "0.0.14b0.post11.dev0+5f6378d"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2770,7 +2770,7 @@ wheels = [
 
 [[package]]
 name = "tabular-orchestrated"
-version = "0.0.14b0.post11.dev0+5f6378d"
+version = "0.0.14b0.post12.dev0+3777c8e"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -2770,7 +2770,7 @@ wheels = [
 
 [[package]]
 name = "tabular-orchestrated"
-version = "0.0.14b0.post1.dev0+651d9c7"
+version = "0.0.14b0.post9.dev0+7668da8"
 source = { editable = "." }
 
 [package.optional-dependencies]
@@ -2798,8 +2798,6 @@ dev = [
     { name = "debugpy" },
     { name = "google-cloud-aiplatform" },
     { name = "hypothesis" },
-    { name = "matplotlib" },
-    { name = "ml-orchestrator", extra = ["editor"] },
     { name = "mypy" },
     { name = "pandas-stubs" },
     { name = "pre-commit" },
@@ -2829,8 +2827,6 @@ dev = [
     { name = "debugpy", specifier = "==1.8.10" },
     { name = "google-cloud-aiplatform" },
     { name = "hypothesis", specifier = ">=6.23.3" },
-    { name = "matplotlib", specifier = "<3.9.4" },
-    { name = "ml-orchestrator", extras = ["editor"] },
     { name = "mypy", specifier = "==1.13.0" },
     { name = "pandas-stubs" },
     { name = "pre-commit", specifier = ">=2.20.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2770,7 +2770,7 @@ wheels = [
 
 [[package]]
 name = "tabular-orchestrated"
-version = "0.0.13b0.post17.dev0+c53cc38"
+version = "0.0.13b0.post18.dev0+39726c7"
 source = { editable = "." }
 dependencies = [
     { name = "setuptools" },
@@ -2785,7 +2785,6 @@ deepchecks = [
 editor = [
     { name = "kfp" },
     { name = "ml-orchestrator", extra = ["editor"] },
-    { name = "pandas-pyarrow" },
 ]
 mljar = [
     { name = "ml-orchestrator" },
@@ -2826,7 +2825,6 @@ requires-dist = [
     { name = "ml-orchestrator", extras = ["editor"], marker = "extra == 'editor'", specifier = ">=0.0.5b0" },
     { name = "mljar-supervised", marker = "extra == 'mljar'", specifier = "==1.1.14" },
     { name = "pandas-pyarrow", marker = "extra == 'deepchecks'" },
-    { name = "pandas-pyarrow", marker = "extra == 'editor'" },
     { name = "pandas-pyarrow", marker = "extra == 'mljar'" },
     { name = "pandas-pyarrow", marker = "extra == 'spliter'" },
     { name = "scikit-learn", marker = "extra == 'spliter'", specifier = ">=1.3.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2770,11 +2770,8 @@ wheels = [
 
 [[package]]
 name = "tabular-orchestrated"
-version = "0.0.13b0.post18.dev0+39726c7"
+version = "0.0.14b0.post1.dev0+651d9c7"
 source = { editable = "." }
-dependencies = [
-    { name = "setuptools" },
-]
 
 [package.optional-dependencies]
 deepchecks = [
@@ -2783,7 +2780,6 @@ deepchecks = [
     { name = "pandas-pyarrow" },
 ]
 editor = [
-    { name = "kfp" },
     { name = "ml-orchestrator", extra = ["editor"] },
 ]
 mljar = [
@@ -2817,9 +2813,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "eh-tabular-deepchecks", marker = "extra == 'deepchecks'", specifier = ">=0.0.4b0" },
-    { name = "kfp", marker = "extra == 'editor'", specifier = ">=2" },
     { name = "ml-orchestrator", marker = "extra == 'deepchecks'" },
-    { name = "ml-orchestrator", marker = "extra == 'editor'" },
     { name = "ml-orchestrator", marker = "extra == 'mljar'" },
     { name = "ml-orchestrator", marker = "extra == 'spliter'" },
     { name = "ml-orchestrator", extras = ["editor"], marker = "extra == 'editor'", specifier = ">=0.0.5b0" },
@@ -2828,7 +2822,6 @@ requires-dist = [
     { name = "pandas-pyarrow", marker = "extra == 'mljar'" },
     { name = "pandas-pyarrow", marker = "extra == 'spliter'" },
     { name = "scikit-learn", marker = "extra == 'spliter'", specifier = ">=1.3.0" },
-    { name = "setuptools", specifier = ">=75.6.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Updated the usage of `uv sync` across workflows and the Makefile to include the `--frozen` flag, ensuring reproducible dependency installations. Adjusted the `pyproject.toml` to refine the structure, added specific paths for `sdist` builds, and removed unnecessary dependencies from optional groups.